### PR TITLE
Upgrade Node from 12 to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ branding:
   icon: hash
   color: gray-dark
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'
 inputs:
   method:


### PR DESCRIPTION
Hi @pplanel , great work here! I've been using this GitHub action in my workflows for a while now.

I've been noticing warnings from GitHub actions about [Node](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/) [deprecations](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) for this action. It appears this action runs on Node 20 instead of the expected Node 12. Since this is a one line change and GitHub actions is actually running this on Node 20 since earlier this year anyway, thought I'd just make a PR for it.